### PR TITLE
add manpages

### DIFF
--- a/man/README
+++ b/man/README
@@ -1,0 +1,24 @@
+Mon, 24 Apr 2000 18:47:32 +0200
+
+These man-pages were created from djb's documentation found at
+http://cr.yp.to/daemontools.html .
+
+Gzip the man-pages and copy them to a subdirectory man8/ of any directory
+found in Your $MANPATH:
+
+  # gzip *.8 ; cp *.8.gz /usr/share/man/man8/
+
+See http://smarden.org/pape/djb/ for recent informations.
+
+G. Pape <pape@smarden.org>
+
+Thu, 16 Nov 2000 12:16:46 +0100
+  * added missing .TP in softlimit.8, option -o is now shown.
+
+Sat, 14 Jul 2001 18:41:17 +0200
+  * man-pages adapted to version 0.76: http://cr.yp.to/daemontools.html
+
+Thu, 31 Jan 2002 10:54:46 +0100
+  * updated readproctitle.8 according to readproctitle.html.
+  * updated multilog.8 according to mutlilog.html.
+  * minor cosmetics.

--- a/man/envdir.8
+++ b/man/envdir.8
@@ -1,0 +1,76 @@
+.TH envdir 8
+.SH NAME
+envdir \- runs another program with environment modified according to files
+in a specified directory.
+.SH SYNOPSIS
+.B envdir
+.I d
+.I child
+.SH DESCRIPTION
+.I d
+is a single argument.
+.I child
+consists of one or more arguments. 
+
+.B envdir
+sets various environment variables as specified by files in the directory
+named
+.IR d .
+It then runs
+.IR child .
+
+If
+.I d
+contains a file named
+.I s
+whose first line is
+.IR t ,
+.B envdir
+removes an environment variable named
+.I s
+if one exists, and then adds an environment variable named
+.I s
+with value
+.IR t .
+The name
+.I s
+must not contain =. Spaces and tabs at the end of
+.I t
+are removed. Nulls in
+.I t
+are changed to newlines in the environment variable. 
+
+If the file
+.I s
+is completely empty (0 bytes long),
+.B envdir
+removes an environment variable named
+.I s
+if one exists, without adding a new variable.
+.SH EXIT CODES
+.B envdir
+exits 111 if it has trouble reading
+.IR d ,
+if it runs out of memory for environment variables, or if it cannot run
+.IR child .
+Otherwise its exit code is the same as that of
+.IR child .
+.SH SEE ALSO
+supervise(8),
+svc(8),
+svok(8),
+svstat(8),
+svscanboot(8),
+svscan(8),
+readproctitle(8),
+fghack(8),
+pgrphack(8),
+multilog(8),
+tai64n(8),
+tai64nlocal(8),
+setuidgid(8),
+envuidgid(8),
+softlimit(8),
+setlock(8)
+
+http://cr.yp.to/daemontools.html

--- a/man/envuidgid.8
+++ b/man/envuidgid.8
@@ -1,0 +1,48 @@
+.TH envuidgid 8
+.SH NAME
+envuidgid \- runs another program with environment variables indicating a
+specified account's uid and gid.
+.SH SYNOPSIS
+.B envuidgid
+.I account
+.I child
+.SH DESCRIPTION
+.I account
+is a single argument.
+.I child
+consists of one or more arguments. 
+
+.B envuidgid
+sets $UID to
+.IR account 's
+uid and $GID to
+.IR account 's
+gid. It then runs
+.IR child .
+.SH EXIT CODES
+.B envuidgid
+exits 111 if it cannot find a UNIX account named
+.IR account ,
+if it runs out of memory for environment variables, or if it cannot run
+.IR child .
+Otherwise its exit code is the same as that of
+.IR child .
+.SH SEE ALSO
+supervise(8),
+svc(8),
+svok(8),
+svstat(8),
+svscanboot(8),
+svscan(8),
+readproctitle(8),
+fghack(8),  
+pgrphack(8),
+multilog(8),
+tai64n(8),
+tai64nlocal(8),
+setuidgid(8),
+envdir(8),
+softlimit(8),
+setlock(8)
+
+http://cr.yp.to/daemontools.html

--- a/man/fghack.8
+++ b/man/fghack.8
@@ -1,0 +1,36 @@
+.TH fghack 8
+.SH NAME
+fghack \- is an anti-backgrounding tool.
+.SH SYNOPSIS
+.B fghack
+.I child
+.SH DESCRIPTION
+.B fghack
+runs
+.I child
+with many extra descriptors writing to a pipe.
+.B fghack
+reads and discards any data written to the pipe. After
+.I child
+has exited and the pipe has been closed,
+.B fghack
+exits. 
+.SH SEE ALSO
+supervise(8),
+svc(8),
+svok(8),
+svstat(8),
+svscanboot(8),
+svscan(8),
+readproctitle(8),
+pgrphack(8),
+multilog(8),
+tai64n(8),
+tai64nlocal(8),
+setuidgid(8),
+envuidgid(8),
+envdir(8),
+softlimit(8),
+setlock(8)
+
+http://cr.yp.to/daemontools.html

--- a/man/multilog.8
+++ b/man/multilog.8
@@ -1,0 +1,285 @@
+.TH multilog 8
+.SH NAME
+multilog \- reads a sequence of lines from stdin and appends selected lines to
+any number of logs.
+.SH SYNOPSIS
+.B multilog
+.I script
+.SH DESCRIPTION
+.I script
+consists of any number of arguments. Each argument specifies one action. The
+actions are carried out in order for each line of input. Note that actions may
+contain shell metacharacters that need to be quoted when
+.B multilog
+is run from a shell. 
+
+.B multilog
+exits 0 when it sees the end of stdin. If stdin has a partial final line then
+.B multilog
+inserts a final newline. 
+
+.B multilog
+writes a message to stderr and exits 111, without reading any input, if it
+runs out of memory or if another
+.B multilog
+process is writing to one of the same automatically rotated logs.
+
+If
+.B multilog
+has trouble writing to disk after it starts reading input, it writes a message
+to stderr, pauses, and tries again, without losing any data. Note that this
+may block any program feeding input to
+.BR multilog .
+
+If
+.B multilog
+receives a TERM signal, it will read and process data until the next newline,
+and then exit, leaving stdin at the first byte of data it has not processed.
+.SH SELECTING LINES
+Each line is initially selected. The action 
+.TP
+.B -\fIpattern
+deselects the line if
+.I pattern
+matches the line. The action 
+.TP
+.B +\fIpattern
+selects the line if
+.I pattern
+matches the line. 
+.PP
+.I pattern
+is a string of stars and non-stars. It matches any concatenation of strings
+matched by all the stars and non-stars in the same order. A non-star matches
+itself. A star before the end of
+.I pattern
+matches any string that does not include the next character in
+.IR pattern .
+A star at the end of
+.I pattern
+matches any string. 
+
+For example, the action 
+
+  +hello
+
+selects hello. It does not select hello world. 
+
+The action 
+
+  -named[*]: Cleaned cache *
+
+deselects named[135]: Cleaned cache of 3121 RRs. The first star matches any
+string that does not include a right bracket. 
+
+The action 
+
+  -*
+
+deselects every line. 
+
+To save memory,
+.B multilog
+actually checks pattern against only the first 1000 characters of each line.
+.SH ALERTS
+The action 
+.TP
+.B e
+prints (the first 200 bytes of) each selected line to stderr.
+.SH STATUS FILES
+The action 
+.TP
+.B =\fIfile
+replaces the contents of
+.I file
+with (the first 1000 bytes of) each selected line, padded with newlines to
+1001 bytes. There is no protection of
+.I file
+against power outages. 
+
+For example, the sequence of actions 
+
+     -*
+     +STAT*
+     =log/status
+
+maintains log/status as a copy of the most recent line starting with STAT. 
+.SH TIMESTAMPING
+The action 
+.TP
+.B t
+inserts an @, a precise timestamp, and a space in front of each line, using
+the same format as
+.BR tai64n (8).
+This is required to be the first action.
+.PP
+Patterns apply to the line after the timestamp is inserted. For example, if
+
+  multilog t '-*' '+* fatal: *' ./main
+
+reads the line
+
+  fatal: out of memory
+
+then it will log a line such as
+
+  @400000003b4a39c23294b13c fatal: out of memory
+
+with the first * matching the timestamp.
+
+You can use
+.BR tai64nlocal (8)
+to convert these timestamps to human-readable form.
+.SH AUTOMATICALLY ROTATED LOGS
+If
+.I dir
+starts with a dot or slash then the action 
+.TP
+.I dir
+appends each selected line to a log named
+.IR dir .
+If
+.I dir
+does not exist,
+.B multilog
+creates it. 
+
+Do not attempt to write to one log from two simultaneous
+.B multilog
+processes, or two actions in one process.
+
+The log format is as follows.
+.I dir
+is a directory containing some number of old log files, a log file named
+.IR current ,
+and other files for
+.B multilog
+to keep track of its actions. Each old log file has a name beginning with @,
+continuing with a precise timestamp showing when the file was finished, and
+ending with one of the following codes:
+.TP
+.B .s
+This file is completely processed and safely written to disk. 
+.TP
+.B .u
+This file was being created at the moment of an outage. It may have been
+truncated and has not been processed. 
+
+Beware that NFS, async filesystems, and softupdates filesystems may discard
+files that were not safely written to disk before an outage.
+
+While
+.B multilog
+is running,
+.I current
+has mode 644. If
+.B multilog
+sees the end of stdin, it writes
+.I current
+safely to disk, and sets the mode of
+.I current
+to 744. When it restarts, it sets the mode of
+.I current
+back to 644 and continues writing new lines. 
+
+When
+.B multilog
+decides that
+.I current
+is big enough, it writes
+.I current
+safely to disk, sets the mode of
+.I current
+to 744, and renames
+.I current
+as an old log file. The action 
+.TP
+.B s\fIsize
+sets the maximum file size for subsequent
+.I dir
+actions.
+.B multilog
+will decide that
+.I current
+is big enough if
+.I current
+has
+.I size
+bytes.
+.RB ( multilog
+will also decide that
+.I current
+is big enough if it sees a newline within 2000 bytes of the maximum file size;
+it tries to finish log files at line boundaries.)
+.I size
+must be between 4096 and 16777215. The default maximum file size is 99999. 
+
+In versions 0.75 and above: If
+.B multilog
+receives an ALRM signal, it immediately decides that
+.I current
+is big enough, if
+.I current
+is nonempty.
+The action 
+.TP
+.B n\fInum
+sets the number of log files for subsequent
+.I dir
+actions. After renaming
+.IR current ,
+if
+.B multilog
+sees
+.I num
+or more old log files, it removes the old log file with the smallest
+timestamp.
+.I num
+must be at least 2. The default number of log files is 10. The action 
+.TP
+.B !\fIprocessor
+sets a
+.I processor
+for subsequent
+.I dir
+actions.
+.B multilog
+will feed
+.I current
+through
+.I processor
+and save the output as an old log file instead of
+.IR current .
+.B multilog
+will also save any output that
+.I processor
+writes to descriptor 5, and make that output readable on descriptor 4 when it
+runs
+.I processor
+on the next log file. For reliability,
+.I processor
+must exit nonzero if it has any trouble creating its output;
+.B multilog
+will then run it again. Note that running
+.I processor
+may block any program feeding input to
+.BR multilog .
+.SH SEE ALSO
+supervise(8),
+svc(8),
+svok(8),
+svstat(8),
+svscanboot(8),
+svscan(8),
+readproctitle(8),
+fghack(8),  
+pgrphack(8),
+tai64n(8),
+tai64nlocal(8),
+setuidgid(8),
+envuidgid(8),
+envdir(8),
+softlimit(8),
+setlock(8)
+
+http://cr.yp.to/daemontools.html

--- a/man/pgrphack.8
+++ b/man/pgrphack.8
@@ -1,0 +1,30 @@
+.TH pgrphack 8
+.SH NAME
+pgrphack \- runs a program in a separate process group.
+.SH SYNOPSIS
+.B pgrphack
+.I child
+.SH DESCRIPTION
+.B pgrphack
+runs
+.I child
+in a new process group.
+.SH SEE ALSO
+supervise(8),
+svc(8),
+svok(8),
+svstat(8),
+svscanboot(8),
+svscan(8),
+readproctitle(8),
+fghack(8),  
+multilog(8),
+tai64n(8),
+tai64nlocal(8),
+setuidgid(8),
+envuidgid(8),
+envdir(8),
+softlimit(8),
+setlock(8)
+
+http://cr.yp.to/daemontools.html

--- a/man/readproctitle.8
+++ b/man/readproctitle.8
@@ -1,0 +1,77 @@
+.TH readproctitle 8
+.SH NAME
+readproctitle \- maintains an automatically rotated log in memory for
+inspection by
+.BR ps (1).
+
+readproctitle is available in daemontools 0.75 and above.
+.SH SYNOPSIS
+.B readproctitle
+.I L
+.I D
+.SH DESCRIPTION
+.I L
+consists of any number of arguments.
+.I D
+is one argument consisting of at least five dots.
+
+.B readproctitle
+reads data into the end of
+.IR D ,
+shifting
+.I D
+to the left to make room. This means that the most recent data is visible
+to process-listing tools such as
+.BR ps (1).
+.B readproctitle
+always leaves three dots at the left of
+.IR D .
+
+For example, if
+
+ readproctitle io errors: ....................
+
+reads the data
+
+ fatal error xyz
+ warning abc
+
+then its command-line arguments change to
+
+ readproctitle io errors: ... xyz!warning abc!
+
+with a newline character in place of each !. Process-listing tools typically
+show the newline character as ? or \\n.
+
+.B readproctitle
+exits when it reaches the end of input.
+
+Beware that most implementations of
+.BR ps (1)
+have small argument-length limits. These limits apply to the total length
+of
+.B readproctitle
+.I L
+.IR D .
+I have not seen a system with a limit below 512 bytes.
+.SH SEE ALSO
+supervise(8),
+svc(8),
+svok(8),
+svstat(8),
+svscanboot(8),
+svscan(8),
+fghack(8),  
+pgrphack(8),
+multilog(8),
+tai64n(8),
+tai64nlocal(8),
+setuidgid(8),
+envuidgid(8),
+envdir(8),
+softlimit(8),
+setlock(8),
+ps(1)
+
+ http://cr.yp.to/daemontools.html
+ http://cr.yp.to/slashcommand.html

--- a/man/setlock.8
+++ b/man/setlock.8
@@ -1,0 +1,84 @@
+.TH setlock 8
+.SH NAME
+setlock \- runs another program with a file locked.
+.SH SYNOPSIS
+.B setlock
+[
+.B \-nNxX
+]
+.I fn
+.I child
+.SH DESCRIPTION
+.I fn
+is a single argument.
+.I child
+consists of one or more arguments. 
+
+.B setlock
+opens
+.I fn
+for writing (creating it if it does not exist), obtains an exclusive lock on
+it, and runs
+.IR child .
+
+Normally the lock disappears when
+.I child
+exits. 
+
+Here's the complete story:
+.I child
+is given a descriptor for a locked ofile pointing to the disk file named
+.IR fn .
+The lock disappears when this ofile is 
+.IP o
+closed by all the processes that have descriptors for it or 
+.IP o
+explicitly unlocked. 
+.SH OPTIONS
+.TP
+.B \-n
+No delay. If
+.I fn
+is locked by another process,
+.B setlock
+gives up. 
+.TP
+.B \-N
+(Default.) Delay. If
+.I fn
+is locked by another process,
+.B setlock
+waits until it can obtain a new lock. 
+.TP
+.B \-x
+If
+.I fn
+cannot be opened (or created) or locked,
+.B setlock
+exits zero. 
+.TP
+.B \-X
+(Default.) If
+.I fn
+cannot be opened (or created) or locked,
+.B setlock
+prints an error message and exits nonzero.
+.SH SEE ALSO
+supervise(8),
+svc(8),
+svok(8),
+svstat(8),
+svscanboot(8),
+svscan(8),
+readproctitle(8),
+fghack(8),  
+pgrphack(8),
+multilog(8),
+tai64n(8),
+tai64nlocal(8),
+setuidgid(8),
+envuidgid(8),
+envdir(8),
+softlimit(8)
+
+http://cr.yp.to/daemontools.html

--- a/man/setuidgid.8
+++ b/man/setuidgid.8
@@ -1,0 +1,48 @@
+.TH setuidgid 8
+.SH NAME
+setuidgid \- runs another program under a specified account's uid and gid.
+.SH SYNOPSIS
+.B setuidgid
+.I account
+.I child
+.SH DESCRIPTION
+.I account
+is a single argument.
+.I child
+consists of one or more arguments. 
+
+.B setuidgid
+sets its uid and gid to
+.IR account 's
+uid and gid, removing all supplementary groups. It then runs
+.IR child .
+
+.B setuidgid
+cannot be run by anyone other than root.
+.SH EXIT CODES
+.B setuidgid
+exits 111 if it cannot find a UNIX account named
+.IB account ,
+if it cannot setgid, if it cannot setuid, or if it cannot run
+.IR child .
+Otherwise its exit code is the same as that of
+.IR child .
+.SH SEE ALSO
+supervise(8),
+svc(8),
+svok(8),
+svstat(8),
+svscanboot(8),
+svscan(8),
+readproctitle(8),
+fghack(8),  
+pgrphack(8),
+multilog(8),
+tai64n(8),
+tai64nlocal(8),
+envuidgid(8),
+envdir(8),
+softlimit(8),
+setlock(8)
+
+http://cr.yp.to/daemontools.html

--- a/man/softlimit.8
+++ b/man/softlimit.8
@@ -1,0 +1,118 @@
+.TH softlimit 8
+.SH NAME
+softlimit \- runs another program with new resource limits.
+.SH SYNOPSIS
+.B softlimit
+[
+.I opts
+]
+.I child
+.SH DESCRIPTION
+.I opts
+is a series of getopt-style options.
+.I child
+consists of one or more arguments. 
+
+.B softlimit
+sets soft resource limits as specified by
+.IR opts .
+It then runs
+.IR child .
+.SH OPTIONS
+In each of the following
+.IB opts ,
+.I n
+may be =, indicating that the soft limit should be set equal to the hard
+limit. 
+
+.I opts
+.B controlling memory use: 
+
+.TP
+.B \-m \fIn
+Same as
+.B \-d
+.I n
+.B \-s
+.I n
+.B \-l
+.I n
+.B \-a
+.IR n .
+.TP
+.B \-d \fIn
+Limit the data segment per process to
+.I n
+bytes.
+.TP
+.B \-s \fIn
+Limit the stack segment per process to
+.I n
+bytes.
+.TP 
+.B \-l \fIn
+Limit the locked physical pages per process to
+.I n
+bytes. This option has no effect on some operating systems.
+.TP
+.B \-a \fIn
+Limit the total of all segments per process to
+.I n
+bytes. This option has no effect on some operating systems. 
+.TP
+.B \-o \fIn
+Limit the number of open file descriptors per process to
+.IR n .
+This option has no effect on some operating systems. 
+.TP
+.B \-p \fIn
+Limit the number of processes per uid to
+.IR n .
+.P
+.I opts
+.B controlling file sizes: 
+.TP
+.B \-f \fIn
+Limit output file sizes to
+.I n
+bytes.
+.TP
+.B \-c \fIn
+Limit core file sizes to
+.I n
+bytes.
+.P
+.B Efficiency
+.I opts:
+.TP
+.B \-r \fIn
+Limit the resident set size to
+.I n
+bytes. This limit is not enforced unless physical memory is full.
+.TP
+.B \-t \fIn
+Limit the CPU time to
+.I n
+seconds. This limit is not enforced except that the process receives a
+SIGXCPU signal after
+.I n
+seconds. 
+.SH SEE ALSO
+supervise(8),
+svc(8),
+svok(8),
+svstat(8),
+svscanboot(8),
+svscan(8),
+readproctitle(8),
+fghack(8),  
+pgrphack(8),
+multilog(8),
+tai64n(8),
+tai64nlocal(8),
+setuidgid(8),
+envuidgid(8),
+envdir(8),
+setlock(8)
+
+http://cr.yp.to/daemontools.html

--- a/man/supervise.8
+++ b/man/supervise.8
@@ -1,0 +1,69 @@
+.TH supervise 8
+.SH NAME
+supervise \- starts and monitors a service.
+.SH SYNOPSIS
+.B supervise
+.I s
+.SH DESCRIPTION
+.B supervise
+switches to the directory named
+.I s
+and starts ./run. It restarts ./run if ./run exits. It pauses for a second
+after starting ./run, so that it does not loop too quickly if ./run exits
+immediately. 
+
+If the file
+.IR s /down
+exists,
+.B supervise
+does not start ./run immediately. You can use
+.BR svc (8)
+to start ./run and to give other commands to
+.BR supervise .
+
+.B supervise
+maintains status information in a binary format inside the directory
+.IR s /supervise,
+which must be writable to
+.BR supervise .
+The status information can be read by
+.BR svstat (8).
+
+.B supervise
+may exit immediately after startup if it cannot find the files it needs in
+.I s
+or if another copy of
+.B supervise
+is already running in
+.IR s .
+Once
+.B supervise
+is successfully running, it will not exit unless it is killed or specifically
+asked to exit. You can use
+.BR svok (8)
+to check whether
+.B supervise
+is successfully running. You can use
+.BR svscan (8)
+to reliably start a collection of
+.B supervise
+processes. 
+.SH SEE ALSO
+svc(8),
+svok(8),
+svstat(8),
+svscanboot(8),
+svscan(8),
+readproctitle(8),
+fghack(8),  
+pgrphack(8),
+multilog(8),
+tai64n(8),
+tai64nlocal(8),
+setuidgid(8),
+envuidgid(8),
+envdir(8),
+softlimit(8),
+setlock(8)
+
+http://cr.yp.to/daemontools.html

--- a/man/svc.8
+++ b/man/svc.8
@@ -1,0 +1,102 @@
+.TH svc 8
+.SH NAME
+svc \- controls services monitored by
+.BR supervise(8).
+.SH SYNOPSIS
+.B svc
+[
+.B \-udopchaitkx
+]
+.I services
+.SH DESCRIPTION
+.I services
+consists of any number of arguments, each argument naming a directory used by
+.BR supervise (8).
+
+.B svc
+applies all the options to each
+.I service
+in turn.
+.SH OPTIONS
+.TP
+.B \-u
+Up. If the
+.I service
+is not running, start it. If the
+.I service
+stops, restart it. 
+.TP
+.B \-d
+Down. If the
+.I service
+is running, send it a TERM signal and then a CONT signal. After it stops, do
+not restart it. 
+.TP
+.B \-o
+Once. If the
+.I service
+is not running, start it. Do not restart it if it stops. 
+.TP
+.B \-p
+Pause. Send the
+.I service
+a STOP signal. 
+.TP
+.B \-c
+Continue. Send the
+.I service
+a CONT signal. 
+.TP
+.B \-h
+Hangup. Send the
+.I service
+a HUP signal. 
+.TP
+.B \-a
+Alarm. Send the
+.I service
+an ALRM signal. 
+.TP
+.B \-i
+Interrupt. Send the
+.I service
+an INT signal. 
+.TP
+.B \-t
+Terminate. Send the
+.I service
+a TERM signal. 
+.TP
+.B \-k
+Kill. Send the
+.I service
+a KILL signal. 
+.TP
+.B \-x
+Exit.
+.BR supervise (8)
+will exit as soon as the
+.I service
+is down. If you use this option on a stable system, you're doing something
+wrong;
+.BR supervise (8)
+is designed to run forever.
+.SH SEE ALSO
+supervise(8),
+svok(8),
+svstat(8),
+svscanboot(8),
+svscan(8),
+readproctitle(8),
+fghack(8),  
+pgrphack(8),
+multilog(8),
+tai64n(8),
+tai64nlocal(8),
+setuidgid(8),
+envuidgid(8),
+envdir(8),
+softlimit(8),
+setlock(8)
+
+http://cr.yp.to/daemontools.html

--- a/man/svok.8
+++ b/man/svok.8
@@ -1,0 +1,39 @@
+.TH svok 8
+.SH NAME
+svok \- checks whether
+.BR supervise(8)
+is running.
+.SH SYNOPSIS
+.B svok
+.I service
+.SH DESCRIPTION
+.B svok
+checks whether
+.BR supervise (8)
+is successfully running in the directory named
+.IR service .
+.SH EXIT CODES
+It silently exits 0 if
+.BR supervise (8)
+is successfully running. It silently exits 100 if
+.BR supervise (8)
+is not successfully running.
+.SH SEE ALSO
+supervise(8),
+svc(8),
+svstat(8),
+svscanboot(8),
+svscan(8),
+readproctitle(8),
+fghack(8),  
+pgrphack(8),
+multilog(8),
+tai64n(8),
+tai64nlocal(8),
+setuidgid(8),
+envuidgid(8),
+envdir(8),
+softlimit(8),
+setlock(8)
+
+http://cr.yp.to/daemontools.html

--- a/man/svscan.8
+++ b/man/svscan.8
@@ -1,0 +1,82 @@
+.TH svscan 8
+.SH NAME
+svscan \- starts and monitors a collection of services
+.SH SYNOPSIS
+.B svscan
+[
+.I directory
+]
+.SH DESCRIPTION
+.B svscan
+starts one
+.BR supervise (8)
+process for each subdirectory of the current directory, up to a limit of 1000
+subdirectories.
+.B svscan
+skips subdirectory names starting with dots.
+.BR supervise (8)
+must be in
+.BR svscan 's
+path.
+
+.B svscan
+optionally starts a pair of
+.BR supervise (8)
+processes, one for a subdirectory
+.IR s ,
+one for
+.IR s\fR/\fBlog ,
+with a pipe between them. It does this if the name
+.I s
+is at most 255 bytes long and
+.I s\fR/\fBlog
+exists. (In versions 0.70 and below, it does this if
+.I s
+is sticky.)
+.B svscan
+needs two free descriptors for each pipe.
+
+Every five seconds,
+.B svscan
+checks for subdirectories again. If it sees a new subdirectory, it starts a
+new
+.BR supervise (8)
+process. If it sees an old subdirectory where a
+.BR supervise (8)
+process has exited, it restarts the
+.BR supervise (8)
+process. In the
+.B log
+case it reuses the same pipe so that no data is lost.
+
+.B svscan
+is designed to run forever. If it has trouble creating a pipe or running
+.BR supervise (8),
+it prints a message to stderr; it will try again five seconds later.
+
+If
+.B svscan
+is given a command-line argument
+.IR directory ,
+it switches to that
+.I directory
+when it starts.
+.SH SEE ALSO
+supervise(8),
+svc(8),
+svok(8),
+svstat(8),
+svscanboot(8),
+readproctitle(8),
+fghack(8),  
+pgrphack(8),
+multilog(8),
+tai64n(8),
+tai64nlocal(8),
+setuidgid(8),
+envuidgid(8),
+envdir(8),
+softlimit(8),
+setlock(8)
+
+http://cr.yp.to/daemontools.html

--- a/man/svscanboot.8
+++ b/man/svscanboot.8
@@ -1,0 +1,55 @@
+.TH svscanboot 8
+.SH NAME
+svscanboot \- starts
+.BR svscan (8)
+in the /service directory, with output and error messages logged through
+.BR readproctitle (8).
+
+svscanboot is available in daemontools 0.75 and above.
+.SH SYNOPSIS
+.B svscanboot
+.SH DESCRIPTION
+.B svscanboot
+runs the pipeline
+
+svscan /service 2>&1 | readproctitle service errors: .....
+
+with 400 dots. The last 400 bytes of error messages from
+.BR svscan (8)
+will be visible to
+.BR ps (1)
+through
+.BR readproctitle (8).
+
+.B svscanboot
+sets $PATH to
+
+ /command:/usr/local/bin:/usr/local/sbin:
+ /bin:/sbin:/usr/bin:/usr/sbin:/usr/X11R6/bin
+
+(all in one line, no space)
+
+and clears all other environment variables. Program writers are encouraged to
+use globally allocated names in
+.BR /command .
+.SH SEE ALSO
+supervise(8),
+svc(8),
+svok(8),
+svstat(8),
+svscan(8),
+readproctitle(8),
+fghack(8),  
+pgrphack(8),
+multilog(8),
+tai64n(8),
+tai64nlocal(8),
+setuidgid(8),
+envuidgid(8),
+envdir(8),
+softlimit(8),
+setlock(8),
+ps(1)
+
+ http://cr.yp.to/daemontools.html
+ http://cr.yp.to/slashcommand.html

--- a/man/svstat.8
+++ b/man/svstat.8
@@ -1,0 +1,35 @@
+.TH svstat 8
+.SH NAME
+svstat \- prints the status of services monitored by
+.BR supervise (8).
+.SH SYNOPSIS
+.B svstat
+.I services
+.SH DESCRIPTION
+.I services
+consists of any number of arguments, each argument naming a directory.
+.B svstat
+prints one human-readable line for each directory, saying whether
+.BR supervise (8)
+is successfully running in that directory, and reporting the status
+information maintained by
+.BR supervise (8).
+.SH SEE ALSO
+supervise(8),
+svc(8),
+svok(8),
+svscanboot(8),
+svscan(8),
+readproctitle(8),
+fghack(8),  
+pgrphack(8),
+multilog(8),
+tai64n(8),
+tai64nlocal(8),
+setuidgid(8),
+envuidgid(8),
+envdir(8),
+softlimit(8),
+setlock(8)
+
+http://cr.yp.to/daemontools.html

--- a/man/tai64n.8
+++ b/man/tai64n.8
@@ -1,0 +1,64 @@
+.TH tai64n 8
+.SH NAME
+tai64n \- puts a precise timestamp on each line.
+.SH SYNOPSIS
+.B tai64n
+.SH DESCRIPTION
+.B tai64n
+reads lines from stdin. For each line, it writes 
+.IP 1
+an @, 
+.IP 2.
+a precise timestamp, 
+.IP 3.
+a space, and 
+.IP 4.
+a copy of the input line 
+
+to stdout. The timestamp indicates the moment that
+.B tai64n
+read the first character of the line. 
+
+.B tai64n
+does not allocate any memory after it starts.
+.SH TIMESTAMPS
+Timestamps used by
+.B tai64n
+are 12-byte TAI64N labels in external TAI64N format, printed as 24 lowercase
+hexadecimal characters. You can use
+.BR tai64nlocal (8)
+to convert the timestamps to a human-readable format. 
+
+For example, the timestamp 4000000037c219bf2ef02e94 refers to the nanosecond
+beginning exactly 935467455.787492500 seconds after the beginning of 1970 TAI;
+37c219bf hexadecimal is 935467455, and 2ef02e94 hexadecimal is 787492500. 
+
+The current implementation of
+.B tai64n
+relies on the UNIX gettimeofday library routine to return the current time as
+the number of TAI seconds since 1970-01-01 00:00:10 TAI. Beware that most
+gettimeofday implementations are not Y2038-compliant. Furthermore, most clocks
+are not set accurately. 
+.SH EXIT CODES
+.B tai64n
+exits 0 when it sees end of input. It exits 111 without an error message if
+it has trouble reading stdin or writing stdout. 
+.SH SEE ALSO
+supervise(8),
+svc(8),
+svok(8),
+svstat(8),
+svscanboot(8),
+svscan(8),
+readproctitle(8),
+fghack(8),  
+pgrphack(8),
+multilog(8),
+tai64nlocal(8),
+setuidgid(8),
+envuidgid(8),
+envdir(8),
+softlimit(8),
+setlock(8)
+
+http://cr.yp.to/daemontools.html

--- a/man/tai64nlocal.8
+++ b/man/tai64nlocal.8
@@ -1,0 +1,60 @@
+.TH tai64nlocal 8
+.SH NAME
+tai64nlocal \- converts precise TAI64N timestamps to a human-readable format.
+.SH SYNOPSIS
+.B tai64nlocal
+.SH DESCRIPTION
+.B tai64nlocal
+reads lines from stdin. If a line does not begin with @,
+.B tai64nlocal
+writes it to stdout without change. If a line begins with @,
+.B tai64nlocal
+looks for a timestamp after the @, in the format printed by
+.BR tai64n (8),
+and writes the line to stdout with the timestamp converted to local time in
+ISO format: YYYY-MM-DD HH:MM:SS.SSSSSSSSS. 
+
+For example, in the US/Pacific time zone, the input line 
+
+  @4000000037c219bf2ef02e94 mark
+
+should be printed as 
+
+  1999-08-23 21:03:43.787492500 mark
+
+Beware, however, that the current implementation of
+.B tai64nlocal
+relies on the UNIX localtime library routine to find the local time. Some
+localtime implementations use a broken time scale that does not account for
+leap seconds. On systems that use the Olson tz library (with an up-to-date
+leap-second table), you can fix this problem by setting your time zone to,
+e.g, right/US/Pacific instead of US/Pacific.
+
+Beware also that most localtime implementations are not Y2038-compliant.
+
+.B tai64nlocal
+does not allocate any memory after it starts, except possibly
+inside localtime.
+.SH EXIT CODES
+.B tai64nlocal
+exits 0 when it sees end of input. It exits 111 without an error message if it
+has trouble reading stdin or writing stdout. 
+.SH SEE ALSO
+supervise(8),
+svc(8),
+svok(8),
+svstat(8),
+svscanboot(8),
+svscan(8),
+readproctitle(8),
+fghack(8),  
+pgrphack(8),
+multilog(8),
+tai64n(8),
+setuidgid(8),
+envuidgid(8),
+envdir(8),
+softlimit(8),
+setlock(8)
+
+http://cr.yp.to/daemontools.html

--- a/src/error.h
+++ b/src/error.h
@@ -3,7 +3,7 @@
 #ifndef ERROR_H
 #define ERROR_H
 
-extern int errno;
+#include <errno.h>
 
 extern int error_intr;
 extern int error_nomem;

--- a/src/error.h
+++ b/src/error.h
@@ -3,7 +3,7 @@
 #ifndef ERROR_H
 #define ERROR_H
 
-#include <errno.h>
+extern int errno;
 
 extern int error_intr;
 extern int error_nomem;


### PR DESCRIPTION
currently its not compiling on my system with the following error:
~~~~
./load envuidgid unix.a byte.a 
/usr/bin/ld: errno: TLS definition in /lib64/libc.so.6 section .tbss mismatches non-TLS reference in envdir.o
/usr/bin/ld: /lib64/libc.so.6: error adding symbols: bad value
collect2: error: ld returned 1 exit status
make: *** [Makefile:111: envdir] Error 1
make: *** Waiting for unfinished jobs....
/usr/bin/ld: errno: TLS definition in /lib64/libc.so.6 section .tbss mismatches non-TLS reference in unix.a(pathexec_run.o)
/usr/bin/ld: /lib64/libc.so.6: error adding symbols: bad value
collect2: error: ld returned 1 exit status
make: *** [Makefile:118: envuidgid] Error 1

~~~~

After adding the patch it works.