### PR TITLE
Extend svc to allow sending the service SIGUSR1 and SIGUSR2

### DIFF
--- a/README-changes.md
+++ b/README-changes.md
@@ -1,0 +1,26 @@
+# Extend functionality of `svc` to be able to send `SIGUSR1` and `SIGUSR2`
+
+The need for additional functionality is described in this [issue](https://github.com/daemontools/daemontools/issues/4).
+
+A corresponding [pull-request](https://github.com/daemontools/daemontools/pull/5).
+
+# Problem:
+
+A _service_ monitored by `supervise` is listening for the signals
+`SIGUSR1` and/or `SIGUSR2`. It is expecting these signals which will
+trigger actions in the _service_.
+
+While under supervision by *daemontools*, the is no practical way to
+send these signals to the _service_.
+
+# Proposed Solution:
+
+The normal way to send signals to a _service_ under supervision is to
+use the `svc` program. For example `svc -h /service/myservice` will send
+a `SIGHUP` to the _service_.
+
+Augmenting `svc` by adding new options to extend the functionality to
+include sending the desired signals will resolve this issue.
+
+The new options `-v` and `-w` are proposed for sending `SIGUSR1` and
+`SIGUSR2`, respectively.

--- a/README.md
+++ b/README.md
@@ -1,39 +1,43 @@
-More info available at: http://cr.yp.to/daemontools.html
+More info available at: [cr.yp.to](http://cr.yp.to/daemontools.html)
 
-How to install daemontools
+How to install `daemontools`
 ==========================
 
-Like any other piece of software (and information generally), daemontools comes with NO WARRANTY.
+Like any other piece of software (and information generally), `daemontools` comes with NO WARRANTY.
 
 
 System requirements
 -------------------
 
 
-daemontools works only under UNIX.
+`daemontools` works only under UNIX.
 
 
 Installation
 ------------
 
-Create a /package directory:
-     mkdir -p /package
-     chmod 1755 /package
-     cd /package
+Create a `/package` directory:  
+```
+mkdir -p /package
+chmod 1755 /package
+cd /package
+```
 
-Download daemontools-0.76.tar.gz into /package. Unpack the daemontools package:
-     gunzip daemontools-0.76.tar
-     tar -xpf daemontools-0.76.tar
-     rm -f daemontools-0.76.tar
-     cd admin/daemontools-0.76
-
-Compile and set up the daemontools programs:
-     package/install
-
-On BSD systems, reboot to start svscan.
+Download `daemontools-0.76.tar.gz` into `/package`. Unpack the `daemontools` package:
+```
+gunzip daemontools-0.76.tar
+tar -xpf daemontools-0.76.tar
+rm -f daemontools-0.76.tar
+cd admin/daemontools-0.76
+```
+Compile and set up the `daemontools` programs:
+```
+package/install
+```
+On BSD systems, reboot to start `svscan`.
 
 --------------------------------------------------------------------------------
 
-To report success:
-     mail djb-sysdeps@cr.yp.to < /package/admin/daemontools/compile/sysdeps
+To report success:  
+     `mail djb-sysdeps@cr.yp.to < /package/admin/daemontools/compile/sysdeps`
 

--- a/src/sig.c
+++ b/src/sig.c
@@ -8,6 +8,8 @@ int sig_child = SIGCHLD;
 int sig_cont = SIGCONT;
 int sig_hangup = SIGHUP;
 int sig_int = SIGINT;
+int sig_usr1 = SIGUSR1;
+int sig_usr2 = SIGUSR2;
 int sig_pipe = SIGPIPE;
 int sig_term = SIGTERM;
 

--- a/src/sig.h
+++ b/src/sig.h
@@ -8,6 +8,8 @@ extern int sig_child;
 extern int sig_cont;
 extern int sig_hangup;
 extern int sig_int;
+extern int sig_usr1;
+extern int sig_usr2;
 extern int sig_pipe;
 extern int sig_term;
 

--- a/src/supervise.c
+++ b/src/supervise.c
@@ -187,6 +187,12 @@ void doit(void)
 	case 'i':
 	  if (pid) kill(pid,SIGINT);
 	  break;
+	case 'v':
+	  if (pid) kill(pid,SIGUSR1);
+	  break;
+	case 'w':
+	  if (pid) kill(pid,SIGUSR2);
+	  break;
 	case 'p':
 	  flagpaused = 1;
 	  announce();

--- a/src/svc.c
+++ b/src/svc.c
@@ -27,7 +27,7 @@ int main(int argc,const char *const *argv)
 
   sig_ignore(sig_pipe);
 
-  while ((opt = getopt(argc,argv,"udopchaitkx")) != opteof)
+  while ((opt = getopt(argc,argv,"udopchaivwtkx")) != opteof)
     if (opt == '?')
       strerr_die1x(100,"svc options: u up, d down, o once, x exit, p pause, c continue, h hup, a alarm, i interrupt, v usr1, w usr2, t term, k kill");
     else

--- a/src/svc.c
+++ b/src/svc.c
@@ -29,7 +29,7 @@ int main(int argc,const char *const *argv)
 
   while ((opt = getopt(argc,argv,"udopchaitkx")) != opteof)
     if (opt == '?')
-      strerr_die1x(100,"svc options: u up, d down, o once, x exit, p pause, c continue, h hup, a alarm, i interrupt, t term, k kill");
+      strerr_die1x(100,"svc options: u up, d down, o once, x exit, p pause, c continue, h hup, a alarm, i interrupt, v usr1, w usr2, t term, k kill");
     else
       if (datalen < sizeof data)
         if (byte_chr(data,datalen,opt) == datalen)


### PR DESCRIPTION
This patch addresses [Issue #4](https://github.com/daemontools/daemontools/issues/4).  It provides an extension to `svc` to allow sending a _service_ monitored by `supervise` the signals `SIGUSR1` and `SIGUSR2`

The new options `-v` and `-w` are for sending `SIGUSR1` and
`SIGUSR2`, respectively.

Additionally, an edited version of [The svc program documentation](https://cr.yp.to/daemontools/svc.html) which includes the new options was created in my [documentation branch](https://github.com/mattmartini/daemontools/tree/documentation). 

